### PR TITLE
Fix for calling can_apply on missing event handler

### DIFF
--- a/rules.js
+++ b/rules.js
@@ -3059,8 +3059,9 @@ states.attacker_combat_cards = {
         })
 
         game.combat_cards.forEach((c) => {
-          if (data.cards[c].faction === game.active && events[data.cards[c].event].can_apply())
-              gen_action_card(c)
+            let evt = events[data.cards[c].event]
+            if (data.cards[c].faction === game.active && evt && evt.can_apply())
+                gen_action_card(c)
         })
 
         gen_action_done()
@@ -3108,7 +3109,8 @@ states.defender_combat_cards = {
         })
 
         game.combat_cards.forEach((c) => {
-            if (data.cards[c].faction === game.active && events[data.cards[c].event].can_apply())
+            let evt = events[data.cards[c].event]
+            if (data.cards[c].faction === game.active && evt && evt.can_apply())
                 gen_action_card(c)
         })
 


### PR DESCRIPTION
This fixes the error coming from the missing ap_withdrawal and cp_withdrawal event handlers by making the combat cards states tolerant of combat cards with no event handler