### PR TITLE
For 2 space retreats, disallow first spaces that don't have a valid second space...

### DIFF
--- a/rules.js
+++ b/rules.js
@@ -4864,6 +4864,9 @@ function get_retreat_options(pieces, from, spaces_to_retreat = 1) {
         if (contains_piece_of_faction(conn, game.attack.attacker))
             return
 
+        if (has_undestroyed_fort(conn, game.attack.attacker) && !is_besieged(conn))
+            return
+
         // Remove any spaces that would violate the Russian NE (non-SR) restriction
         if (!check_russian_ne_restriction(pieces, conn))
             return


### PR DESCRIPTION
…unless no space has a valid second space