### PR TITLE
Bidding for sides

### DIFF
--- a/images.css
+++ b/images.css
@@ -66,6 +66,7 @@
 .marker.tu_rp { background-image: url(pieces/tu_rp.webp); background-size: 45px 45px; }
 .marker.us_rp { background-image: url(pieces/us_rp.webp); background-size: 45px 45px; }
 .marker.vp { background-image: url(pieces/vp.webp); background-size: 45px 45px; }
+.marker.vp_bid { background-image: url(pieces/vp.webp); background-size: 45px 45px; opacity: 50%; }
 .marker.ap_bid { background-image: url(pieces/ap_bid.webp); background-size: 45px 45px; }
 .marker.cp_bid { background-image: url(pieces/cp_bid.webp); background-size: 45px 45px; }
 

--- a/images.css
+++ b/images.css
@@ -66,6 +66,8 @@
 .marker.tu_rp { background-image: url(pieces/tu_rp.webp); background-size: 45px 45px; }
 .marker.us_rp { background-image: url(pieces/us_rp.webp); background-size: 45px 45px; }
 .marker.vp { background-image: url(pieces/vp.webp); background-size: 45px 45px; }
+.marker.ap_bid { background-image: url(pieces/ap_bid.webp); background-size: 45px 45px; }
+.marker.cp_bid { background-image: url(pieces/cp_bid.webp); background-size: 45px 45px; }
 
 /* TEMP: For markers that are missing images, use CSS to insert some text */
 .marker { line-height: 10px; font-family: var(--font-small); font-size: 8px; text-align: center; }

--- a/play.html
+++ b/play.html
@@ -105,12 +105,12 @@
 <aside>
 	<div id="roles">
 		<div class="role" id="role_Allied_Powers">
-			<div class="role_name">Allied Powers</div>
+			<div class="role_name" id="ap_role_name">Allied Powers</div>
 			<div class="role_stat" id="ap_hand"></div>
 			<div class="role_user">-</div>
 		</div>
 		<div class="role" id="role_Central_Powers">
-			<div class="role_name">Central Powers</div>
+			<div class="role_name" id="cp_role_name">Central Powers</div>
 			<div class="role_stat" id="cp_hand"></div>
 			<div class="role_user">-</div>
 		</div>

--- a/play.js
+++ b/play.js
@@ -2913,6 +2913,9 @@ function update_map() {
         }
     }
 
+    action_button('ap', "Allied Powers")
+    action_button('cp', "Central Powers")
+
     action_button("single_op", "Automatic Operation")
 
     action_button("select_all", "Select all")
@@ -2952,11 +2955,16 @@ function update_map() {
         "A different unit in the same space has earned a -1 DRM marker to entrench here.\nDo you still want to entrench with this unit instead?"
     )
 
+    for (let i = 0; i <= 4; ++i) {
+        action_button_with_argument('bid', i, `${i} VP`)
+    }
+
     action_button("pass", "Pass")
 
     action_button("skip", "Skip")
     action_button("next", "Next")
     action_button("done", "Done")
+    action_button("accept", "Accept")
     action_button("undo", "Undo")
 }
 

--- a/play.js
+++ b/play.js
@@ -2968,6 +2968,18 @@ function update_map() {
     action_button("undo", "Undo")
 }
 
+function update_roles() {
+    let ap_name = document.getElementById("ap_role_name")
+    let cp_name = document.getElementById("cp_role_name")
+    if (view.is_bidding) {
+        ap_name.innerText = 'Player 1'
+        cp_name.innerText = 'Player 2'
+    } else {
+        ap_name.innerText = 'Allied Powers'
+        cp_name.innerText = 'Central Powers'
+    }
+}
+
 function update_card_zones() {
     // Update hand
     ui.cards.replaceChildren()
@@ -3040,6 +3052,7 @@ function update_card_zones() {
 function on_update() {
     hide_supply()
     update_map()
+    update_roles()
 }
 
 // INITIALIZE CLIENT

--- a/play.js
+++ b/play.js
@@ -889,10 +889,21 @@ function show_score_summary() {
 
         current_score += event_total
 
-        // Bid
-        // TODO
+        // Bid (after it has been scored)
+        if (view.bid_was) {
+            append_header(`Bid for Sides`)
+            append_score(`Bid`, view.bid_was)
+            current_score += view.bid_was
+        }
 
         let endgame_score = current_score
+
+        // Bid (before being scored)
+        if (view.bid) {
+            append_header(`Bid for Sides (Applied at End Game)`)
+            append_score(`Bid`, view.bid)
+            endgame_score += view.bid
+        }
 
         // Historical Scenario VPs that would score if the scenario ended by armistice or at turn 20
         append_header(`Historical Scenario End Game VPs`)

--- a/play.js
+++ b/play.js
@@ -1023,6 +1023,7 @@ const marker_info = {
     vp: {name: "VP", type: "vp", counter: "marker vp", size: 45},
     ap_bid: {name: "AP Bid", type: "ap_bid", counter: "marker ap_bid", size: 45},
     cp_bid: {name: "CP Bid", type: "cp_bid", counter: "marker cp_bid", size: 45},
+    vp_with_bid: {name: "VP with Bid", type: "vp_with_bid", counter: "marker vp_bid", size: 45},
 
     // War status markers
     ap_war_status: {name: "AP War Status", type: "ap_war_status", counter: "marker ap war_status", size: 45},
@@ -2530,9 +2531,18 @@ function update_general_records_track() {
 
     update_general_record("vp", Math.max(0, Math.min(40, view.vp)))
     if (view.bid < 0)
-        update_general_record("cp_bid", Math.max(0, Math.min(40, view.vp + view.bid)))
+        update_general_record("cp_bid", Math.abs(view.bid))
+    else
+        update_general_record("cp_bid", 0, true)
     if (view.bid > 0)
-        update_general_record("ap_bid", Math.max(0, Math.min(40, view.vp + view.bid)))
+        update_general_record("ap_bid", view.bid)
+    else
+        update_general_record("ap_bid", 0, true)
+    if (view.bid)
+        update_general_record("vp_with_bid", Math.max(0, Math.min(40, view.vp + view.bid)))
+    else
+        update_general_record("vp_with_bid", 0, true)
+
 
 
     update_general_record("combined_war_status", view.cp.ws + view.ap.ws)

--- a/play.js
+++ b/play.js
@@ -1010,6 +1010,8 @@ const marker_info = {
         cp: {name: "CP OOS", type: "cp_oos", counter: "marker cp oos", size: 45}
     },
     vp: {name: "VP", type: "vp", counter: "marker vp", size: 45},
+    ap_bid: {name: "AP Bid", type: "ap_bid", counter: "marker ap_bid", size: 45},
+    cp_bid: {name: "CP Bid", type: "cp_bid", counter: "marker cp_bid", size: 45},
 
     // War status markers
     ap_war_status: {name: "AP War Status", type: "ap_war_status", counter: "marker ap war_status", size: 45},
@@ -2516,6 +2518,11 @@ function update_general_records_track() {
     general_records_stacks.forEach((stack) => stack.length = 0)
 
     update_general_record("vp", Math.max(0, Math.min(40, view.vp)))
+    if (view.bid < 0)
+        update_general_record("cp_bid", Math.max(0, Math.min(40, view.vp + view.bid)))
+    if (view.bid > 0)
+        update_general_record("ap_bid", Math.max(0, Math.min(40, view.vp + view.bid)))
+
 
     update_general_record("combined_war_status", view.cp.ws + view.ap.ws)
     update_general_record("ap_war_status", view.ap.ws)

--- a/rules.js
+++ b/rules.js
@@ -1385,6 +1385,8 @@ function goto_start_bidding() {
         game.bid_for_side = 0
         game.bid_winner = 0
         game.current_bid = 0
+        log_h2(`Bid for Sides`)
+        log(`${player_name(game.active)} bids first`)
     } else {
         goto_complete_setup()
     }
@@ -1439,8 +1441,25 @@ function get_scenario_for_bid(old_scenario, faction, bid) {
     return old_scenario
 }
 
+function player_name(role) {
+    switch (role) {
+        case AP:
+        case AP_ROLE:
+            return 'Player 1'
+        case CP:
+        case CP_ROLE:
+            return 'Player 2'
+    }
+    return ''
+}
+
 states.bidding = {
+    inactive() {
+        view.prompt = `Waiting for ${player_name(other_role(game.active))} to bid for sides`
+        view.is_bidding = true
+    },
     prompt() {
+        view.is_bidding = true
         const max_bid = get_max_bid_for_scenario(game.scenario)
         if (game.bid_for_side === 0) {
             view.prompt = `Which side would you prefer to play?`
@@ -1460,19 +1479,24 @@ states.bidding = {
     ap() {
         push_undo()
         game.bid_for_side = AP
+        log(`Bidding for ${faction_name(AP)}`)
     },
     cp() {
         push_undo()
         game.bid_for_side = CP
+        log(`Bidding for ${faction_name(AP)}`)
     },
     bid(i) {
         game.bid_winner = game.active
         game.current_bid = i
+        log(`${player_name(game.active)} bid ${i} VP`)
         switch_active_faction()
         if (i === get_max_bid_for_scenario(game.scenario))
             this.accept()
     },
     accept() {
+        log(`Bid accepted`)
+        log(`${player_name(game.bid_winner)} will play ${faction_name(game.bid_for_side)}`)
         const needs_swap = short_faction(game.bid_winner) !== game.bid_for_side
         const new_scenario = get_scenario_for_bid(game.scenario, game.bid_for_side, game.current_bid)
         game.$pie = { swap: needs_swap, new_scenario }
@@ -1491,17 +1515,12 @@ states.bidding = {
 
 function goto_complete_setup() {
     if (is_any_historical_scenario(game.scenario)) {
-        game.options.hand_size = 8
-        game.failed_entrench = []
         set_up_standard_decks(true)
         goto_start_turn()
     } else if (is_any_great_war_scenario(game.scenario)) {
-        game.options.hand_size = 8
-        game.failed_entrench = []
         set_up_great_war_scenario_decks()
         goto_start_great_war_scenario()
     } else {
-        game.options.hand_size = 7
         set_up_standard_decks(false)
         goto_start_turn()
     }
@@ -7367,6 +7386,10 @@ states.draw_cards_phase = {
 
 function other_faction(faction) {
     return faction === CP ? AP : CP
+}
+
+function other_role(role) {
+    return role === AP_ROLE ? CP_ROLE : AP_ROLE
 }
 
 // === ACTIONS ===

--- a/rules.js
+++ b/rules.js
@@ -518,6 +518,7 @@ exports.view = function(state, current) {
         actions: null,
         turn: game.turn,
         vp: game.vp,
+        bid: game.bid,
         us_entry: game.us_entry,
         russian_capitulation: game.russian_capitulation,
         last_card: game.last_card,

--- a/rules.js
+++ b/rules.js
@@ -1399,6 +1399,34 @@ function get_max_bid_for_scenario(scenario) {
     return 3
 }
 
+function get_bid_from_scenario(scenario) {
+    switch (scenario) {
+        case HISTORICAL_AP_1:
+        case GREAT_WAR_AP_1:
+            return -1
+        case HISTORICAL_AP_2:
+        case GREAT_WAR_AP_2:
+            return -2
+        case HISTORICAL_AP_3:
+        case GREAT_WAR_AP_3:
+            return -3
+        case HISTORICAL_AP_4:
+            return -4
+        case HISTORICAL_CP_1:
+        case GREAT_WAR_CP_1:
+            return 1
+        case HISTORICAL_CP_2:
+        case GREAT_WAR_CP_2:
+            return 2
+        case HISTORICAL_CP_3:
+        case GREAT_WAR_CP_3:
+            return 3
+        case HISTORICAL_CP_4:
+            return 4
+    }
+    return 0
+}
+
 const HISTORICAL_SCENARIOS = {
     'ap': [
         HISTORICAL,
@@ -1431,13 +1459,12 @@ const GREAT_WAR_SCENARIOS = {
     ]
 }
 
-function get_scenario_for_bid(old_scenario, faction, bid) {
-    if (faction !== AP && faction !== CP)
-        throw new Error('Invalid faction bid: ' + faction)
+function get_scenario_for_bid(old_scenario, bid_for_faction, bid) {
+    let favored_faction = other_faction(bid_for_faction)
     if (is_any_historical_scenario(old_scenario)) {
-        return HISTORICAL_SCENARIOS[faction][bid]
+        return HISTORICAL_SCENARIOS[favored_faction][bid]
     } else if (is_any_great_war_scenario(old_scenario)) {
-        return GREAT_WAR_SCENARIOS[faction][bid]
+        return GREAT_WAR_SCENARIOS[favored_faction][bid]
     }
     return old_scenario
 }
@@ -1500,7 +1527,7 @@ states.bidding = {
         log(`${player_name(game.bid_winner)} will play ${faction_name(game.bid_for_side)}`)
         const needs_swap = short_faction(game.bid_winner) !== game.bid_for_side
         const new_scenario = get_scenario_for_bid(game.scenario, game.bid_for_side, game.current_bid)
-        game.$pie = { swap: needs_swap, new_scenario }
+        game.$pie = { swap: needs_swap, scenario: new_scenario }
 
         game.bid = game.current_bid
         if (game.bid_for_side === CP)
@@ -1510,11 +1537,15 @@ states.bidding = {
         delete game.bid_winner
         delete game.current_bid
 
+        clear_undo()
         goto_complete_setup()
     }
 }
 
 function goto_complete_setup() {
+    if (game.bid === 0)
+        game.bid = get_bid_from_scenario(game.scenario)
+
     if (is_any_historical_scenario(game.scenario)) {
         set_up_standard_decks(true)
         goto_start_turn()

--- a/rules.js
+++ b/rules.js
@@ -353,7 +353,42 @@ exports.roles = [ AP_ROLE, CP_ROLE ]
 
 const HISTORICAL = "Historical"
 const GREAT_WAR = "The Great War"
-exports.scenarios = [ HISTORICAL, GREAT_WAR ]
+const HISTORICAL_BID = "Historical (Bid for sides)"
+const HISTORICAL_AP_1 = "Historical AP +1"
+const HISTORICAL_AP_2 = "Historical AP +2"
+const HISTORICAL_AP_3 = "Historical AP +3"
+const HISTORICAL_AP_4 = "Historical AP +4"
+const HISTORICAL_CP_1 = "Historical CP +1"
+const HISTORICAL_CP_2 = "Historical CP +2"
+const HISTORICAL_CP_3 = "Historical CP +3"
+const HISTORICAL_CP_4 = "Historical CP +4"
+const GREAT_WAR_BID = "The Great War (Bid for Sides)"
+const GREAT_WAR_AP_1 = "The Great War AP +1"
+const GREAT_WAR_AP_2 = "The Great War AP +2"
+const GREAT_WAR_AP_3 = "The Great War AP +3"
+const GREAT_WAR_CP_1 = "The Great War CP +1"
+const GREAT_WAR_CP_2 = "The Great War CP +2"
+const GREAT_WAR_CP_3 = "The Great War CP +3"
+exports.scenarios = [
+    HISTORICAL,
+    GREAT_WAR,
+    HISTORICAL_BID,
+    GREAT_WAR_BID,
+    HISTORICAL_AP_1,
+    HISTORICAL_AP_2,
+    HISTORICAL_AP_3,
+    HISTORICAL_AP_4,
+    HISTORICAL_CP_1,
+    HISTORICAL_CP_2,
+    HISTORICAL_CP_3,
+    HISTORICAL_CP_4,
+    GREAT_WAR_AP_1,
+    GREAT_WAR_AP_2,
+    GREAT_WAR_AP_3,
+    GREAT_WAR_CP_1,
+    GREAT_WAR_CP_2,
+    GREAT_WAR_CP_3,
+]
 
 function use_historical_scenario_rules() {
     return true // Other rules are not implemented

--- a/rules.js
+++ b/rules.js
@@ -353,7 +353,7 @@ exports.roles = [ AP_ROLE, CP_ROLE ]
 
 const HISTORICAL = "Historical"
 const GREAT_WAR = "The Great War"
-const HISTORICAL_BID = "Historical (Bid for sides)"
+const HISTORICAL_BID = "Historical (Bid for Sides)"
 const HISTORICAL_AP_1 = "Historical AP +1"
 const HISTORICAL_AP_2 = "Historical AP +2"
 const HISTORICAL_AP_3 = "Historical AP +3"
@@ -392,6 +392,18 @@ exports.scenarios = [
 
 function use_historical_scenario_rules() {
     return true // Other rules are not implemented
+}
+
+function is_any_historical_scenario(scenario) {
+    return scenario.includes(HISTORICAL)
+}
+
+function is_any_great_war_scenario(scenario) {
+    return scenario.includes(GREAT_WAR)
+}
+
+function is_any_bidding_scenario(scenario) {
+    return scenario.includes("Bid for Sides")
 }
 
 exports.action = function (state, current, action, arg) {
@@ -667,21 +679,17 @@ exports.setup = function (seed, scenario, options) {
         log("Supply warnings and rollbacks disabled.")
     }
 
-    if (game.scenario === HISTORICAL) {
+    if (is_any_historical_scenario(game.scenario)) {
         game.options.hand_size = 8
         game.failed_entrench = []
-        set_up_standard_decks(true)
-        goto_start_turn()
-    } else if (scenario === GREAT_WAR) {
+    } else if (is_any_great_war_scenario(game.scenario)) {
         game.options.hand_size = 8
         game.failed_entrench = []
-        set_up_great_war_scenario_decks()
-        goto_start_great_war_scenario()
     } else {
         game.options.hand_size = 7
-        set_up_standard_decks(false)
-        goto_start_turn()
     }
+
+    goto_start_bidding()
 
     return game
 }
@@ -699,6 +707,7 @@ function create_empty_game_state(seed, scenario) {
 
         turn: 1, // Turn number
         vp: 10, // Current VP, can move up or down
+        bid: 0, // Amount of VP bid, negative for CP, positive for AP
         us_entry: 0, // US commitment level
         russian_capitulation: 0, // Russian capitulation level
         ops: 0, // Ops points for the current action
@@ -1364,6 +1373,137 @@ function set_up_played_event(c, turn = 1) {
         game.events.entrench = turn
     } else {
         game.events[card_data.event] = turn
+    }
+}
+
+// === BIDDING FOR SIDES ===
+
+function goto_start_bidding() {
+    if (is_any_bidding_scenario(game.scenario)) {
+        game.state = 'bidding'
+        game.active = random(2) === 1 ? AP_ROLE : CP_ROLE
+        game.bid_for_side = 0
+        game.bid_winner = 0
+        game.current_bid = 0
+    } else {
+        goto_complete_setup()
+    }
+}
+
+function get_max_bid_for_scenario(scenario) {
+    if (is_any_historical_scenario(scenario))
+        return 4
+    return 3
+}
+
+const HISTORICAL_SCENARIOS = {
+    'ap': [
+        HISTORICAL,
+        HISTORICAL_AP_1,
+        HISTORICAL_AP_2,
+        HISTORICAL_AP_3,
+        HISTORICAL_AP_4
+    ],
+    'cp': [
+        HISTORICAL,
+        HISTORICAL_CP_1,
+        HISTORICAL_CP_2,
+        HISTORICAL_CP_3,
+        HISTORICAL_CP_4
+    ]
+}
+
+const GREAT_WAR_SCENARIOS = {
+    'ap': [
+        GREAT_WAR,
+        GREAT_WAR_AP_1,
+        GREAT_WAR_AP_2,
+        GREAT_WAR_AP_3
+    ],
+    'cp': [
+        GREAT_WAR,
+        GREAT_WAR_CP_1,
+        GREAT_WAR_CP_2,
+        GREAT_WAR_CP_3
+    ]
+}
+
+function get_scenario_for_bid(old_scenario, faction, bid) {
+    if (faction !== AP && faction !== CP)
+        throw new Error('Invalid faction bid: ' + faction)
+    if (is_any_historical_scenario(old_scenario)) {
+        return HISTORICAL_SCENARIOS[faction][bid]
+    } else if (is_any_great_war_scenario(old_scenario)) {
+        return GREAT_WAR_SCENARIOS[faction][bid]
+    }
+    return old_scenario
+}
+
+states.bidding = {
+    prompt() {
+        const max_bid = get_max_bid_for_scenario(game.scenario)
+        if (game.bid_for_side === 0) {
+            view.prompt = `Which side would you prefer to play?`
+            gen_action(AP)
+            gen_action(CP)
+        } else if (game.bid_winner === 0) {
+            view.prompt = `How many VP will you bid to play ${faction_name(game.bid_for_side)}`
+            for (let i = 0; i <= max_bid; ++i)
+                gen_action('bid', i)
+        } else {
+            view.prompt = `Opponent bid ${game.current_bid} to play ${faction_name(game.bid_for_side)} -- accept or outbid them?`
+            gen_action('accept')
+            for (let i = game.current_bid + 1; i <= max_bid; ++i)
+                gen_action('bid', i)
+        }
+    },
+    ap() {
+        push_undo()
+        game.bid_for_side = AP
+    },
+    cp() {
+        push_undo()
+        game.bid_for_side = CP
+    },
+    bid(i) {
+        game.bid_winner = game.active
+        game.current_bid = i
+        switch_active_faction()
+        if (i === get_max_bid_for_scenario(game.scenario))
+            this.accept()
+    },
+    accept() {
+        const needs_swap = short_faction(game.bid_winner) !== game.bid_for_side
+        const new_scenario = get_scenario_for_bid(game.scenario, game.bid_for_side, game.current_bid)
+        game.$pie = { swap: needs_swap, new_scenario }
+
+        game.bid = game.current_bid
+        if (game.bid_for_side === CP)
+            game.bid *= -1
+
+        delete game.bid_for_side
+        delete game.bid_winner
+        delete game.current_bid
+
+        goto_complete_setup()
+    }
+}
+
+function goto_complete_setup() {
+    if (is_any_historical_scenario(game.scenario)) {
+        game.options.hand_size = 8
+        game.failed_entrench = []
+        set_up_standard_decks(true)
+        goto_start_turn()
+    } else if (is_any_great_war_scenario(game.scenario)) {
+        game.options.hand_size = 8
+        game.failed_entrench = []
+        set_up_great_war_scenario_decks()
+        goto_start_great_war_scenario()
+    } else {
+        game.options.hand_size = 7
+        set_up_standard_decks(false)
+        goto_start_turn()
     }
 }
 

--- a/rules.js
+++ b/rules.js
@@ -580,6 +580,9 @@ exports.view = function(state, current) {
         action_state: game.action_state
     }
 
+    if (game.bid_was)
+        view.bid_was = game.bid_was
+
     if (current === AP_ROLE) {
         view.hand = game.ap.hand
     } else if (current === CP_ROLE) {
@@ -6993,6 +6996,13 @@ function get_game_result_by_vp() {
             game.vp -= 2 // If the Fall of the Tsar event was not played, subtract 2 VP
             log(`-2 VP -- ${card_name(FALL_OF_THE_TSAR)} was not played`)
         }
+    }
+
+    if (game.bid !== 0 && game.bid !== undefined) {
+        game.vp += game.bid
+        log(`${game.bid > 0 ? '+' : ''}${game.bid} VP -- Bid for sides applied`)
+        game.bid_was = game.bid
+        game.bid = 0 // Set this to zero so the client will stop showing the bid now that it's applied
     }
 
     let cp_threshold = game.events.treaty_of_brest_litovsk > 0 ? 11 : 13


### PR DESCRIPTION
Implement bidding for sides as outlined in section 5.6 of the rules
* Bidding follows the model of the Imperial Struggle implementation, with multiple scenarios representing specific bid values
* $pie is used to specify if the sides should swap and the new scenario
* The client fakes the side names as 'Player 1' and 'Player 2' during the bidding phase
* The winning bid is shown on the General Records Track as either and AP Bid or CP Bid marker
* There is a semi-transparent VP marker on the General Records Track to show the current VP including the bid
* The Score Summary dialog shows the bid included in projected end game scoring before it is applied, then in the actual score once it has been applied at the end of the game
